### PR TITLE
Change how entity ID and entity name are constructed

### DIFF
--- a/pkg/discovery/metric_datasource.go
+++ b/pkg/discovery/metric_datasource.go
@@ -179,10 +179,10 @@ func loadJSONStream(metricEndpoint string, resp []byte) (*data.Topology, error) 
 
 	rb := bytes.NewBuffer(resp)
 	reader := bufio.NewReader(rb)
-	parser := jsparser.NewJSONParser(reader, "Scope")
+	parser := jsparser.NewJSONParser(reader, "scope")
 	var scope string
 	for json := range parser.Stream() {
-		glog.Infof("Scope %++v\n", json.StringVal)
+		glog.Infof("Scope %+v", json.StringVal)
 		scope = json.StringVal
 	}
 

--- a/pkg/dtofactory/entity_builder_test.go
+++ b/pkg/dtofactory/entity_builder_test.go
@@ -102,7 +102,7 @@ func TestEntityBuilder(t *testing.T) {
 	// expected entity properties
 	expectedTestEntity := &TestEntity{
 		id:          getEntityId(entityType, difEntity.EntityId, scope),
-		displayName: getDisplayEntityName(entityType, difEntity.EntityId, scope),
+		displayName: difEntity.EntityId,
 		eType:       entityType,
 		soldComms:   make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO),
 		boughtComms: make(map[proto.EntityDTO_EntityType]map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO),

--- a/pkg/dtofactory/generic_entity_builder.go
+++ b/pkg/dtofactory/generic_entity_builder.go
@@ -38,7 +38,7 @@ func (eb *GenericEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 
 	entityBuilder := builder.
 		NewEntityDTOBuilder(eb.entityType, id).
-		DisplayName(getDisplayEntityName(eb.entityType, eb.difEntity.EntityId, eb.scope))
+		DisplayName(eb.difEntity.EntityId)
 
 	mergePropertiesMap := make(map[string]string)
 	commoditiesMap := make(map[proto.CommodityDTO_CommodityType][]*builder.CommodityDTOBuilder) //[]*proto.CommodityDTO)

--- a/pkg/dtofactory/proxy_provider_builder.go
+++ b/pkg/dtofactory/proxy_provider_builder.go
@@ -35,7 +35,7 @@ func (eb *ProxyProviderEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	id := getEntityId(eb.entityType, eb.entityId, eb.scope)
 	glog.Infof("****** building proxy provider ... %s", id)
 	entityBuilder := builder.NewEntityDTOBuilder(eb.entityType, id).
-		DisplayName(getDisplayEntityName(eb.entityType, eb.entityId, eb.scope))
+		DisplayName(eb.entityId)
 
 	// no matching id
 	// set properties

--- a/pkg/dtofactory/util.go
+++ b/pkg/dtofactory/util.go
@@ -23,12 +23,7 @@ func EntityType(difType data.DIFEntityType) *proto.EntityDTO_EntityType {
 func getEntityId(entityType proto.EntityDTO_EntityType, entityName, scope string) string {
 	eType := proto.EntityDTO_EntityType_name[int32(entityType)]
 
-	return fmt.Sprintf("%s-%s:%s", eType, entityName, scope)
-}
-func getDisplayEntityName(entityType proto.EntityDTO_EntityType, entityName, scope string) string {
-	eType := proto.EntityDTO_EntityType_name[int32(entityType)]
-
-	return fmt.Sprintf("%s:%s[%s]", entityName, scope, eType)
+	return fmt.Sprintf("%s-%s-%s", eType, entityName, scope)
 }
 
 func getEntityPropertyNameValue(name, value string) *proto.EntityDTO_EntityProperty {


### PR DESCRIPTION
Change how entity ID and entity name are constructed.

* DTO entity ID:
`DTOEntityType-DIFEntityID-Scope`, where `Scope` is set in the JSON returned from the metric server. Fixed a bug where `scope` is not correctly parsed.

* DTO entity name:
`DIFEntityID`. There is no need to append EntityType to the display name, which is cluttered.

Before the change:
![image](https://user-images.githubusercontent.com/10012486/80267000-e1bbe980-866c-11ea-81d8-e2baeb0ab7b6.png)

After the change:
![image](https://user-images.githubusercontent.com/10012486/80267156-af5ebc00-866d-11ea-95f7-b719efc2e9bd.png)

