### PR TITLE
Patch Application commodity for proxy VM

### DIFF
--- a/configs/app-supply-chain-config.yaml
+++ b/configs/app-supply-chain-config.yaml
@@ -89,11 +89,9 @@ supplyChainNode:
     mergedEntityMetaData:
       keepStandalone: false
       matchingMetadata:
-        returnType: STRING
         matchingData:
           - matchingProperty:
               propertyName: IP
-        externalEntityReturnType: STRING
         externalEntityMatchingProperty:
           - matchingField:
               fieldName: id
@@ -265,21 +263,19 @@ supplyChainNode:
     mergedEntityMetaData:
       keepStandalone: false
       matchingMetadata:
-        returnType: STRING
         matchingData:
           - matchingProperty:
               propertyName: IP
-        externalEntityReturnType: STRING
         externalEntityMatchingProperty:
           - matchingProperty:
               propertyName: IP
-        commoditiesSold:
-          - RESPONSE_TIME
-          - TRANSACTION
-          - DB_MEM
-          - DB_CACHE_HIT_RATE
-          - CONNECTION
-          - KPI
+      commoditiesSold:
+        - RESPONSE_TIME
+        - TRANSACTION
+        - DB_MEM
+        - DB_CACHE_HIT_RATE
+        - CONNECTION
+        - KPI
   - templateClass: VIRTUAL_MACHINE
     templateType: BASE
     templatePriority: -2
@@ -303,6 +299,8 @@ supplyChainNode:
                 - virtual_machine_data
               fieldName: ipAddress
             delimiter: ","
+      commoditiesSold:
+        - APPLICATION
   - templateClass: CONTAINER
     templateType: BASE
     templatePriority: -1


### PR DESCRIPTION
This PR modifies the supply chain definition of the DIF probe to:

* Patch `Application` commodity from proxy VM to the external VM
* Fix indentation problems for the DB server patch sold commodities
* Remove deprecated return types from `matchingMetadata` configuration

This PR fixes the issue of https://vmturbo.atlassian.net/browse/OM-60345.