### PR TITLE
Allow stitching between DIF and UDT

### DIFF
--- a/example/jira/jiraturbo.go
+++ b/example/jira/jiraturbo.go
@@ -16,8 +16,7 @@ const (
 	url             = "https://vmturbo.atlassian.net/rest/api/2/search?jql=project='Operations%20Manager'&maxResults=0"
 	auth            = "fakeAuth"
 	cookie          = "fakeCookie"
-	appID           = "Turbonomic-turbonomic-http://prometheus-server:9090"
-	stitchingID     = "BUSINESS_APPLICATION-Turbonomic-turbonomic-http://prometheus-server:9090"
+	appID           = "Turbonomic-turbonomic-http://prometheus-server:9090" // [Name]-[Namespace]-[Source]
 	scope           = "Prometheus"
 	defaultCapacity = 60000
 )
@@ -65,8 +64,7 @@ func sendTopology(w http.ResponseWriter, r *http.Request) {
 	}
 	// Create business app entity
 	bizApp := dif.
-		NewDIFEntity(appID, "businessApplication").
-		Matching(stitchingID)
+		NewDIFEntity(appID, "businessApplication")
 	key := "Total Tickets"
 	capacity := float64(defaultCapacity)
 	bizApp.AddMetrics("kpi", []*dif.DIFMetricVal{{
@@ -86,7 +84,7 @@ func sendTopology(w http.ResponseWriter, r *http.Request) {
 			"failed to marshal %v into json: %v", topology, err))
 		return
 	}
-	glog.Infof("%v", tickets)
+	glog.Infof("%s", result)
 	// Send response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/pkg/dtofactory/commodity_key_builder.go
+++ b/pkg/dtofactory/commodity_key_builder.go
@@ -93,8 +93,8 @@ func (kb *CommodityKeyBuilder) GetBoughtCommKey(internalProvider bool) (keys []s
 		}
 		if keySupplierTypes.Contains(*eType) {
 			for pId := range pMap {
-				id := getEntityId(*eType, pId, kb.scope)
-				keys = append(keys, id)
+				key := getKey(*eType, pId, kb.scope)
+				keys = append(keys, key)
 			}
 		}
 	}
@@ -106,8 +106,8 @@ func (kb *CommodityKeyBuilder) GetBoughtCommKey(internalProvider bool) (keys []s
 		}
 		if keySupplierTypes.Contains(*eType) {
 			for pId := range pMap {
-				id := getEntityId(*eType, pId, kb.scope)
-				keys = append(keys, id)
+				key := getKey(*eType, pId, kb.scope)
+				keys = append(keys, key)
 			}
 		}
 	}

--- a/pkg/dtofactory/entity_builder_test.go
+++ b/pkg/dtofactory/entity_builder_test.go
@@ -102,7 +102,7 @@ func TestEntityBuilder(t *testing.T) {
 
 	// expected entity properties
 	expectedTestEntity := &TestEntity{
-		id:          getEntityId(entityType, difEntity.EntityId, scope),
+		id:          difEntity.EntityId,
 		displayName: difEntity.EntityId,
 		eType:       entityType,
 		soldComms:   make(map[proto.CommodityDTO_CommodityType]*proto.CommodityDTO),

--- a/pkg/dtofactory/generic_entity_builder.go
+++ b/pkg/dtofactory/generic_entity_builder.go
@@ -34,7 +34,7 @@ func NewGenericEntityBuilder(entityType proto.EntityDTO_EntityType,
 func (eb *GenericEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	var dto *proto.EntityDTO
 
-	entityID := getEntityId(eb.entityType, eb.difEntity.EntityId, eb.scope)
+	entityID := eb.difEntity.EntityId
 	glog.V(3).Infof("Building %s", entityID)
 
 	entityBuilder := builder.
@@ -88,10 +88,9 @@ func (eb *GenericEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 		}
 		// Adding the provider and associated bought commodities to the entity builder
 		for _, pId := range providerIds {
-			providerId := getEntityId(*providerType, pId, eb.scope)
-			glog.V(3).Infof("%s --> adding internal provider %s", entityID, providerId)
+			glog.V(3).Infof("%s --> adding internal provider %s", entityID, pId)
 			entityBuilder.
-				Provider(builder.CreateProvider(*providerType, providerId)).
+				Provider(builder.CreateProvider(*providerType, pId)).
 				BuysCommodities(boughtCommodities)
 		}
 	}
@@ -140,7 +139,7 @@ func (eb *GenericEntityBuilder) externalProviders(supplyChainNode *registration.
 		// Construct the IDs of the external providers
 		var providerIds []string
 		for pId := range pMap {
-			providerIds = append(providerIds, getEntityId(*eType, pId, eb.scope))
+			providerIds = append(providerIds, pId)
 		}
 		// Make sure for HOSTING provider type, there is no more than 1 providers
 		if scHostedByProviderType[*eType] == "HOSTING" && len(pMap) > 1 {

--- a/pkg/dtofactory/proxy_provider_builder.go
+++ b/pkg/dtofactory/proxy_provider_builder.go
@@ -31,9 +31,8 @@ func NewProxyProviderEntityBuilder(entityType proto.EntityDTO_EntityType, entity
 func (eb *ProxyProviderEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	var dto *proto.EntityDTO
 
-	id := getEntityId(eb.entityType, eb.entityId, eb.scope)
-	glog.Infof("Building proxy provider %s", id)
-	entityBuilder := builder.NewEntityDTOBuilder(eb.entityType, id).
+	glog.Infof("Building proxy provider %s", eb.entityId)
+	entityBuilder := builder.NewEntityDTOBuilder(eb.entityType, eb.entityId).
 		DisplayName(eb.entityId)
 
 	// no matching id
@@ -49,15 +48,17 @@ func (eb *ProxyProviderEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	supportedComms := supplyChainNode.SupportedComms
 	supportedAccessComms := supplyChainNode.SupportedAccessComms
 
+	key := getKey(eb.entityType, eb.entityId, eb.scope)
+
 	var soldCommodities []*proto.CommodityDTO
 	for commType, commVal := range supportedComms {
 		commBuilder := builder.NewCommodityDTOBuilder(commType)
 		if commVal.Key != nil {
-			commBuilder.Key(id)
+			commBuilder.Key(key)
 		}
 		soldCommodity, err := commBuilder.Create()
 		if err != nil {
-			glog.Errorf("Failed to create sold commodity %v for %v: %v", commType, id, err)
+			glog.Errorf("Failed to create sold commodity %v for %v: %v", commType, eb.entityId, err)
 			continue
 		}
 		soldCommodities = append(soldCommodities, soldCommodity)
@@ -65,9 +66,9 @@ func (eb *ProxyProviderEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 
 	for commType := range supportedAccessComms {
 		//using the provider id as the key
-		soldCommodity, err := builder.NewCommodityDTOBuilder(commType).Key(id).Create()
+		soldCommodity, err := builder.NewCommodityDTOBuilder(commType).Key(key).Create()
 		if err != nil {
-			glog.Errorf("Failed to create sold commodity %v for %v: %v", commType, id, err)
+			glog.Errorf("Failed to create sold commodity %v for %v: %v", commType, eb.entityId, err)
 			continue
 		}
 		soldCommodities = append(soldCommodities, soldCommodity)

--- a/pkg/dtofactory/util.go
+++ b/pkg/dtofactory/util.go
@@ -19,9 +19,8 @@ func EntityType(difType data.DIFEntityType) *proto.EntityDTO_EntityType {
 	return &eType
 }
 
-func getEntityId(entityType proto.EntityDTO_EntityType, entityName, scope string) string {
+func getKey(entityType proto.EntityDTO_EntityType, entityName, scope string) string {
 	eType := proto.EntityDTO_EntityType_name[int32(entityType)]
-
 	return fmt.Sprintf("%s-%s-%s", eType, entityName, scope)
 }
 


### PR DESCRIPTION
This PR fixes the issue of stitching between DIF and UDT probes. 

## Background
Stitching between DIF and UDT is done by matching OID in a custom stitching operation. This is the implementation to support our simple stitching use case for now. We may need to revisit the implementation if more complex use cases arise.

Several important notes:

* The `SharedEntityCustomProbePreStitchingOperation` in the platform matches entities coming from custom probes using OIDs. In order to match an entity from DIF to an entity from UDT, one needs to identify the numeric OID of the entity from UDT, and makes sure to set the uniqueID of the entity in the JSON input to DIF to the same value. For example:

```
  "topology": [
    {
      "uniqueId": "284672456377888",
      "type": "businessApplication",
      "name": "Custom-BApp-App",
      "metrics": {
       ...
       ...
```

* After merging all entities with the same OID, the `SharedEntityCustomProbePreStitchingOperation` keeps the most recently discovered entity, and removes all other entities. So it is possible that the entity discovered from the UDT probe gets dropped eventually (user will notice this when looking at the target name and target type in the entity details).

* The display name of the merged entity is decided by sorting the display names from all entities lexicographically and picking the first one. So it is best to make sure to set the display name of the entity in the JSON input to DIF probe to the same as that from the UDT probe.

## Fixes

* Modifies DIF probe to send the raw ID defined in the `uniqueId` field in the JSON input as is to the server. Do **NOT** prefix the raw ID with entity type, or append it with scope.
* Modifies the `jiraturbo` example to remove the matching identifier for the BA entity. The matching identifier is not necessary as the matching is done by OID.

## Tests

* Make sure TTwT is working fine.
* Create a BA topology on the UI (through the UDT probe). Set up DIF and a simple metric server to send in a BA entity with the same numeric OID and display name, and some response time and transaction metric. Confirm that the stitching is done successfully. 
![image](https://user-images.githubusercontent.com/10012486/89433339-35c87680-d710-11ea-8ec6-369773f5f06e.png)
