### PR TITLE
Properly support proxy Application hosted on proxy VM

### DIFF
--- a/pkg/discovery/discovery_client.go
+++ b/pkg/discovery/discovery_client.go
@@ -229,7 +229,7 @@ func (d *DIFDiscoveryClient) buildEntities(repository *data.DIFRepository, scope
 			if existingEntity, seen := idToEntityMap[difEntityId]; seen {
 				// Entities with the same ID and same type will be merged. Entities with the same ID but different
 				// types will be rejected.
-				glog.Errorf("Duplicated entity ID detected with different entity types. Entity ID: %v," +
+				glog.Errorf("Duplicated entity ID detected with different entity types. Entity ID: %v,"+
 					" Entity types: %v, %v", difEntityId, existingEntity.EntityType, difEntityType)
 				continue
 			}

--- a/pkg/dtofactory/generic_entity_builder.go
+++ b/pkg/dtofactory/generic_entity_builder.go
@@ -151,10 +151,13 @@ func (eb *GenericEntityBuilder) externalProviders(supplyChainNode *registration.
 		boughtCommodities := eb.externalBoughtCommodities(*eType, commoditiesMap)
 		// Add the provider and associated bought commodities to the entity builder
 		// Provider entity will be created by the proxy_provider_builder
+		// Create a unique ID for the proxy provider (a hashed value of entity type, id and scope). We do not expect
+		// to stitch the proxy provider with the real provider using the custom stitching operation (which stitch
+		// based on entity IDs).
 		for _, providerId := range providerIds {
 			glog.V(3).Infof("%s --> adding external provider %s::%s", entityID, pType, providerId)
 			entityBuilder.
-				Provider(builder.CreateProvider(*eType, providerId)).
+				Provider(builder.CreateProvider(*eType, getProxyEntityId(*eType, providerId, eb.scope))).
 				BuysCommodities(boughtCommodities)
 		}
 	}

--- a/pkg/dtofactory/proxy_provider_builder.go
+++ b/pkg/dtofactory/proxy_provider_builder.go
@@ -32,7 +32,9 @@ func (eb *ProxyProviderEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	var dto *proto.EntityDTO
 
 	glog.Infof("Building proxy provider %s", eb.entityId)
-	entityBuilder := builder.NewEntityDTOBuilder(eb.entityType, eb.entityId).
+	entityBuilder := builder.
+		NewEntityDTOBuilder(eb.entityType,
+			getProxyEntityId(eb.entityType, eb.entityId, eb.scope)).
 		DisplayName(eb.entityId)
 
 	// no matching id

--- a/pkg/dtofactory/util.go
+++ b/pkg/dtofactory/util.go
@@ -1,6 +1,8 @@
 package dtofactory
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/turbonomic/data-ingestion-framework/pkg/data"
@@ -22,6 +24,12 @@ func EntityType(difType data.DIFEntityType) *proto.EntityDTO_EntityType {
 func getKey(entityType proto.EntityDTO_EntityType, entityName, scope string) string {
 	eType := proto.EntityDTO_EntityType_name[int32(entityType)]
 	return fmt.Sprintf("%s-%s-%s", eType, entityName, scope)
+}
+
+func getProxyEntityId(entityType proto.EntityDTO_EntityType, entityId, scope string) string {
+	hasher := sha1.New()
+	hasher.Write([]byte(fmt.Sprintf("%s%s%s", entityType, entityId, scope)))
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func getEntityPropertyNameValue(name, value string) *proto.EntityDTO_EntityProperty {


### PR DESCRIPTION
This fix addresses an issue introduced by #25, where we send the raw ID of an entity defined in the `JSON` input to the Platform. As a result, we are creating the same ID for a proxy Application, and the proxy VM that hosts the proxy Application, causing stitching issues in the Platform [OM-62601](https://vmturbo.atlassian.net/browse/OM-62601).

This fix:
* Creates a unique ID for the proxy VM provider, which will be different than the ID of the proxy Application that is hosted by the proxy VM. There should be no use case to stitch proxy VM with a real VM **through the custom stitching operation**
* Skip creating entity DTOs that has the same ID but different entity types, and log proper error message
* Add tests

Tests:
* Deploy `kafka` and kafka prometheus exporter `jmx-kafka` on a test VM
* Configure promethues configuration of an XL instance to scrape metrics from the above `jmx-kafka`
```
  prometheus:
    enabled: true
    extraScrapeConfigs:  |
      - job_name: jmx-kafka
        metrics_path: /metrics
        static_configs:
          - targets: ['10.10.168.193:7071']"
```
* Configure `prometurbo` to construct entities and metrics from `jmx-kafka`:
```
  prometurbo:
    enabled: true
    extraPrometheusExporters: |
      jmx-kafka:
        entities:
        - type: application
          hostedOnVM: true
          metrics:
            - type: collectionTime
              queries:
                used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job!="xl"}[10m]))/600*100'
          attributes:
            ip:
              label: instance
              matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
            id:
              label: instance
              matches: (?P<hostIP>\d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??)
              as: Application-$hostIP
              isIdentifier: true
    prometheusServers: |
      server1:
        # The URL of the prometheus server
        url: http://prometheus-server:9090
        # The list of supported exporters for the above prometheus server
        exporters:
          - turbonomic
          - jmx-kafka
```
* The proxy VM is stitched to a real VM discovered by VCenter probe:
* See the `Application Component` entity and the `Remaining GC Capacity` commodity being populated in the UI:
![image](https://user-images.githubusercontent.com/10012486/93783744-158a4380-fbfa-11ea-8691-71542380ea69.png)
* Check topology dump, and confirm the proxy App (type 69) is selling `RemainingGCCapacity` commodity (type 111), and buying `Application` commodity (type 56) from the real VM (type 10) with correct key:
```
          {
            "entity": {
              "entityType": 69,
              "typeSpecificInfo": {},
              "oid": "73638685171024",
              "displayName": "Application-10.10.168.193",
              "environmentType": "ON_PREM",
              "commoditySoldList": [
                {
                  "commodityType": {
                    "type": 111
                  },
                  "used": 99.9190742239366,
                  "peak": 0.0,
                  "capacity": 100.0,
                  "effectiveCapacityPercentage": 97.0,
                  "isResizeable": false,
                  "isThin": true,
                  "active": true,
                  "historicalUsed": {
                    "histUtilization": 99.91624450683594,
                    "timeSlot": []
                  },
                  "historicalPeak": {
                    "histUtilization": 0.0,
                    "timeSlot": []
                  },
                  "displayName": "",
                  "aggregates": []
                },
                {
                  "commodityType": {
                    "type": 56,
                    "key": ""
                  },
                  "used": 0.0,
                  "peak": 0.0,
                  "capacity": 100000.0,
                  "isResizeable": false,
                  "isThin": true,
                  "active": true,
                  "displayName": "",
                  "aggregates": []
                }
              ],
              "commoditiesBoughtFromProviders": [
                {
                  "providerId": "73628425536208",
                  "providerEntityType": 10,
                  "commodityBought": [
                    {
                      "commodityType": {
                        "type": 56,
                        "key": "VIRTUAL_MACHINE-10.10.168.193-Prometheus"
                      },
                      "used": 0.0,
                      "peak": 0.0,
                      "active": true,
                      "displayName": "",
                      "aggregates": []
                    }
                  ]
                }
              ],
              "entityState": "POWERED_ON",
              "entityPropertyMap": {
                "IP": "10.10.168.193",
                "origin": "PROXY"
              },
              "analysisSettings": {
                "isAvailableAsProvider": true,
                "shopTogether": false,
                "cloneable": false,
                "suspendable": false,
                "isEligibleForResizeDown": true,
                "controllable": true,
                "providerMustClone": false,
                "deletable": true
              },
              "origin": {
                "discoveryOrigin": {
                  "discoveringTargetIds": [],
                  "lastUpdatedTime": "1600700397594",
                  "discoveredTargetData": {
                    "73541333762240": {
                      "vendorId": "Application-10.10.168.193"
                    }
                  }
                }
              },
              "connectedEntityList": [],
              "tags": {
                "tags": {}
              }
            }
          },

```
