### PR TITLE
Remove MergedEntityMetadata for Service in DIF supply chain definition

### DIFF
--- a/configs/app-supply-chain-config.yaml
+++ b/configs/app-supply-chain-config.yaml
@@ -143,25 +143,6 @@ supplyChainNode:
           - commodityType: KPI
             key: key-placeholder
             optional: true
-    mergedEntityMetaData:
-      keepStandalone: false
-      matchingMetadata:
-        matchingData:
-          - matchingProperty:
-              propertyName: IP
-        externalEntityMatchingProperty:
-          - matchingProperty:
-              propertyName: IP
-            delimiter: ","
-      commoditiesSold:
-        - RESPONSE_TIME
-        - TRANSACTION
-        - KPI
-      commoditiesBought:
-        - providerType: APPLICATION_COMPONENT
-          commodityMetadata:
-            - RESPONSE_TIME
-            - TRANSACTION
   - templateClass: APPLICATION_COMPONENT
     templateType: BASE
     templatePriority: -1


### PR DESCRIPTION
This change is to work together with [OM-66819](https://vmturbo.atlassian.net/browse/OM-66819), where we implemented a custom stitching operation for `Service` entities coming from DIF probe. The current data driven stitching operation defined in the DIF probe supply chain is outdated, so it should be removed, otherwise, the custom stitching will not take effect.

This change should only be merged after `turbodif:8.1.1` has been officially released.