### PR TITLE
Introduce ignoreCommodityIfPresent command line option to DIF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 go:
-  - 1.17
+  - 1.17.6
 
 go_import_path: github.com/turbonomic/data-ingestion-framework
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,16 +28,17 @@ func main() {
 		SpewKeys:              false,
 	}
 
+	// Set up arguments specific to DIF
+	args := conf.NewDIFProbeArgs()
+	// Parse the flags
 	flag.Parse()
 
+	// Print out critical information
 	glog.Infof("Running turbodif VERSION: %s, GIT_COMMIT: %s, BUILD_TIME: %s",
 		version.Version, version.GitCommit, version.BuildTime)
-
-	args := conf.NewDIFProbeArgs(flag.CommandLine)
-	flag.Parse()
+	glog.Infof("IgnoreIfPresent is set to %v for all commodities.", *args.IgnoreCommodityIfPresent)
 
 	s, err := pkg.NewDIFTAPService(args)
-
 	if err != nil {
 		glog.Fatalf("Failed to run turbodif: %v", err)
 	}

--- a/pkg/conf/args.go
+++ b/pkg/conf/args.go
@@ -5,23 +5,29 @@ import (
 )
 
 const (
-	defaultDiscoveryIntervalSec = 600
-	defaultKeepStandalone       = false
+	defaultDiscoveryIntervalSec     = 600
+	defaultKeepStandalone           = false
+	defaultIgnoreCommodityIfPresent = false
 )
 
-// Arguments for the TurboDIF Probe
+// DIFProbeArgs specifies arguments for the TurboDIF Probe
 type DIFProbeArgs struct {
 	// The discovery interval in seconds for running the probe
 	DiscoveryIntervalSec *int
-	// Boolean to indicate if the the discovered entities that are not stitched should be deleted or kept in the server
+	// Boolean to indicate if the discovered entities that are not stitched should be deleted or kept in the server
 	KeepStandalone *bool
+	// Boolean to indicate if a discovered commodity should be merged when the commodity of the same type already
+	// exists in the external entity
+	IgnoreCommodityIfPresent *bool
 }
 
-func NewDIFProbeArgs(fs *flag.FlagSet) *DIFProbeArgs {
+func NewDIFProbeArgs() *DIFProbeArgs {
 	p := &DIFProbeArgs{}
 
-	p.DiscoveryIntervalSec = fs.Int("discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
-	p.KeepStandalone = fs.Bool("keepStandalone", defaultKeepStandalone, "Do we keep non-stitched entities")
+	p.DiscoveryIntervalSec = flag.Int("discovery-interval-sec", defaultDiscoveryIntervalSec, "The discovery interval in seconds")
+	p.KeepStandalone = flag.Bool("keepStandalone", defaultKeepStandalone, "Do we keep non-stitched entities")
+	p.IgnoreCommodityIfPresent = flag.Bool("ignoreCommodityIfPresent", defaultIgnoreCommodityIfPresent,
+		"Do we ignore a commodity that already exists")
 
 	return p
 }

--- a/pkg/dif_tap_service.go
+++ b/pkg/dif_tap_service.go
@@ -87,12 +87,15 @@ func createTAPService(args *conf.DIFProbeArgs) (*service.TAPService, error) {
 		glog.Errorf("Error while parsing the supply chain config file %s: %++v", supplyChainConf, err)
 		os.Exit(1)
 	}
-	// Registration client - configured with the supply chain definition
-	registrationClient, err := registration.NewDIFRegistrationClient(supplyChainConfig, difConf.TargetTypeSuffix)
-
+	supplyChain, err := registration.NewSupplyChain(supplyChainConfig)
 	if err != nil {
-		glog.Fatalf("error: %v", err)
+		glog.Errorf("Error while parsing the supply chain: %+v", err)
+		os.Exit(1)
 	}
+	supplyChain.IgnoreIfPresent(*args.IgnoreCommodityIfPresent)
+	// Registration client - configured with the supply chain definition
+	registrationClient := registration.NewDIFRegistrationClient(supplyChain, difConf.TargetTypeSuffix)
+
 	// Discovery client - target type, target address, supply chain
 	targetType := registrationClient.TargetType()
 	probeCategory := registrationClient.ProbeCategory()

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -1,7 +1,6 @@
 package registration
 
 import (
-	"fmt"
 	"github.com/golang/glog"
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/turbonomic/data-ingestion-framework/pkg/conf"
@@ -16,23 +15,17 @@ const (
 	propertyId string = "id"
 )
 
-// Implements the TurboRegistrationClient interface
+// DIFRegistrationClient implements the TurboRegistrationClient interface
 type DIFRegistrationClient struct {
 	TargetTypeSuffix string
 	supplyChain      *SupplyChain
 }
 
-func NewDIFRegistrationClient(supplyChainConfig *conf.SupplyChainConfig, targetTypeSuffix string) (*DIFRegistrationClient, error) {
-	supplyChain, err := NewSupplyChain(supplyChainConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing supply chain %v", err)
-
-	}
+func NewDIFRegistrationClient(supplyChain *SupplyChain, targetTypeSuffix string) *DIFRegistrationClient {
 	return &DIFRegistrationClient{
 		TargetTypeSuffix: targetTypeSuffix,
 		supplyChain:      supplyChain,
-	}, nil
-
+	}
 }
 
 func (p *DIFRegistrationClient) GetSupplyChainDefinition() []*proto.TemplateDTO {


### PR DESCRIPTION
### Background
This MR introduce a `ignoreCommodityIfPresent` (default to `false`) command line option to DIF:

* By default, commodities discovered by DIF probe overwrites those discovered by native probes for the matching entities. A typical use case is that Azure probe discovers Virtual Memory capacity, and the DIF probe discovers Virtual Memory used value for the same virtual machine, and after stitching Virtual Memory used discovered by DIF can be patched onto the virtual machine
* We have a new use case now to skip merging commodities if the same type already exist on external entities. To support this use case, we are adding `ignoreCommodityIfPresent` command line option
* The `ignoreCommodityIfPresent` command line option applies to all commodities on all entities defined in the supply chain definition, i.e., it is a flag per DIF Probe instance

### Test
* Set up a metric server that discovers the following metrics
```json
{
	"version": "v1",
	"updateTime": 1641915462,
	"scope": "Test",
	"source": "",
	"topology": [{
		"uniqueId": "test",
		"type": "virtualMachine",
		"name": "test",
		"hostedOn": null,
		"matchIdentifiers": {
			"ipAddress": "10.0.136.239"
		},
		"partOf": null,
		"metrics": {
			"cpu": [{
				"average": 3072
			}]
		}
	}]
}
``` 
* Start DIF with `ignoreCommodityIfPresent` set to `false` (default), and run overnight
* Restart DIF with `ignoreCommodityIfPresent` set to `true`, observe that the matching VM VCPU is not patched

![image](https://user-images.githubusercontent.com/10012486/149049442-2d8e2d3e-aff6-4c83-8805-b0e2936c9f4c.png)
