### PR TITLE
Add ignoreCommodityIfPresent to DIF operator and helm deployment

### DIFF
--- a/deploy/turbodif-operator/deploy/crds/charts_v1alpha1_turbodif_cr.yaml
+++ b/deploy/turbodif-operator/deploy/crds/charts_v1alpha1_turbodif_cr.yaml
@@ -26,9 +26,9 @@ spec:
   # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
   #targetTypeSuffix: CustomMetricSource
 
-  #targetConfig:
-    #keepStandalone: false
-
-  #args:
-    # logging level
-    #logginglevel: 2
+  # Command line arguments
+  args:
+    # Logging level 2 to 4
+    logginglevel: 2
+    # When set to true, ignore merging a commodity if a commodity of the same type already exists
+    #ignoreCommodityIfPresent: false

--- a/deploy/turbodif-operator/helm-charts/turbodif/templates/deployment.yaml
+++ b/deploy/turbodif-operator/helm-charts/turbodif/templates/deployment.yaml
@@ -24,8 +24,10 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --keepStandalone={{ .Values.targetConfig.keepStandalone }}
             - --v={{ .Values.args.logginglevel }}
+  {{- if .Values.args.ignoreCommodityIfPresent }}
+            - --ignoreCommodityIfPresent=true
+  {{- end }}
           volumeMounts:
           - name: turbodif-config
             mountPath: /etc/turbodif

--- a/deploy/turbodif-operator/helm-charts/turbodif/values.yaml
+++ b/deploy/turbodif-operator/helm-charts/turbodif/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/turbodif
-  tag: 8.1.2
+  tag: 8.4.4
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -28,10 +28,9 @@ restAPIConfig:
 # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
 targetTypeSuffix: CustomMetricSource
 
-targetConfig:
-  keepStandalone: false
-
 args:
   # logging level
   logginglevel: 2
+  # When set to true, ignore merging a commodity if a commodity of the same type already exists
+  ignoreCommodityIfPresent: false
 

--- a/deploy/turbodif/templates/deployment.yaml
+++ b/deploy/turbodif/templates/deployment.yaml
@@ -24,8 +24,10 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --keepStandalone={{ .Values.targetConfig.keepStandalone }}
             - --v={{ .Values.args.logginglevel }}
+  {{- if .Values.args.ignoreCommodityIfPresent }}
+            - --ignoreCommodityIfPresent=true
+  {{- end }}
           volumeMounts:
           - name: turbodif-config
             mountPath: /etc/turbodif

--- a/deploy/turbodif/values.yaml
+++ b/deploy/turbodif/values.yaml
@@ -5,7 +5,7 @@
 # Replace the image with desired version
 image:
   repository: turbonomic/turbodif
-  tag: 8.1.2
+  tag: 8.4.4
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -28,10 +28,9 @@ restAPIConfig:
 # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
 targetTypeSuffix: CustomMetricSource
 
-targetConfig:
-  keepStandalone: false
-
 args:
   # logging level
   logginglevel: 2
+  # When set to true, ignore merging a commodity if a commodity of the same type already exists
+  ignoreCommodityIfPresent: false
 


### PR DESCRIPTION
This PR adds `ignoreCommodityIfPresent` command line option to:

*  DIF operator deployment
*  DIF helm deployment

For example:

```yaml
args:
  # logging level
  logginglevel: 2
  # When set to true, ignore merging a commodity if a commodity of the same type already exists
  ignoreCommodityIfPresent: true
```

This PR also removes the `keepStandalone` command line option, as it is never used. The `keepStandalone` is defined in the supply chain definition yaml file.