### PR TITLE
Fix global keepStandalone flag and set the default to true

### DIFF
--- a/pkg/conf/args.go
+++ b/pkg/conf/args.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	defaultDiscoveryIntervalSec     = 600
-	defaultKeepStandalone           = false
+	defaultKeepStandalone           = true
 	defaultIgnoreCommodityIfPresent = false
 )
 

--- a/pkg/dtofactory/generic_entity_builder.go
+++ b/pkg/dtofactory/generic_entity_builder.go
@@ -2,6 +2,7 @@ package dtofactory
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/turbonomic/data-ingestion-framework/pkg/data"
@@ -118,6 +119,7 @@ func (eb *GenericEntityBuilder) BuildEntity() (*proto.EntityDTO, error) {
 	if err != nil {
 		return nil, err
 	}
+	dto.KeepStandalone = &eb.keepStandalone
 
 	logDebug(protobuf.MarshalTextString(dto))
 	return dto, nil


### PR DESCRIPTION
# Intent
Make the `keepStandalone` flag work at the probe level

# Background
The current `turbodif` support `keepStandalone` flag which is used to control if the entity is shown on the UI or not, but this flag doesn't work as desired.  

# Implementation
Pass this value of this flag to entity builder and set it to the proxy entityDTO.  Change the flag value to `true` which keep consistent with the old behaviour. 

# Test Done

## Case 1: Test the default value `true`
**1. Remove all of Cloud Native targets in the appliance**
![image](https://user-images.githubusercontent.com/61252360/179844701-3c9e719e-1579-42cc-b3f0-a771bc36b33b.png)

**2. Make sure the `prometurbo` is running and broadcast and check the service list. There are lots of service which are not stitched and shown in the UI**
![image](https://user-images.githubusercontent.com/61252360/179845696-878e67d7-39f2-43d0-91cf-306318225812.png)
![image](https://user-images.githubusercontent.com/61252360/179846007-b9b26450-83a3-46ec-9f49-4a99a045d297.png)

**3. Add back `kubeturbo` target on the same cluster in the appliance, that will trigger the stitching operation**
```
[turbo@node1 ~]$ k scale deployment kubeturbo --replicas=1
deployment.apps/kubeturbo scaled
```

![image](https://user-images.githubusercontent.com/61252360/179846504-6abb0de6-b4f4-4dc1-b9e4-237ee3eebc00.png)

**4. Rediscovery the target and broadcast, all of service should be stitched**
![image](https://user-images.githubusercontent.com/61252360/179846744-351022d9-963b-41ee-8df6-b0b1221012e0.png)
![image](https://user-images.githubusercontent.com/61252360/179846894-05993ce6-6440-446e-bf9b-2b24ab1a7a6c.png)

## Case 2: Test the value `false`
**1. Stop the operator and edit the `prometurbo` deployment, add the argument `-keepStandalone=false`**
![image](https://user-images.githubusercontent.com/61252360/179848230-f69c5278-1f33-4799-b6dc-3365a5832dc9.png)


**2. Remove all of Cloud Native targets in the appliance**
![image](https://user-images.githubusercontent.com/61252360/179848280-fe5e588a-c605-4b96-9e5c-0a70ed7eab18.png)



**3. Check the UI and find all of un-stitched service entities are not shown in the UI**
![image](https://user-images.githubusercontent.com/61252360/179848453-3072ab2c-233d-4856-a782-a7167cecb0a1.png)
![image](https://user-images.githubusercontent.com/61252360/179848491-f9f2bbf0-83ae-48b1-9f92-31437db00228.png)

