### PR TITLE
Update to go 1.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ services:
   - docker
 
 go:
-  - 1.17.6
+  - 1.19.1
 
 go_import_path: github.com/turbonomic/data-ingestion-framework
 
 before_install:
-  - go get -v github.com/mattn/goveralls
+  - go install -v github.com/mattn/goveralls@HEAD
 
 script:
   - make fmtcheck

--- a/pkg/dtofactory/generic_entity_builder.go
+++ b/pkg/dtofactory/generic_entity_builder.go
@@ -194,7 +194,7 @@ func (eb *GenericEntityBuilder) soldCommodities(commoditiesMap CommoditiesByType
 				continue
 			} else if commTemplate.Key == nil {
 				if soldComm.Key != nil {
-					glog.V(4).Info("Commodity key is not defined in the template for %+v but is "+
+					glog.V(4).Infof("Commodity key is not defined in the template for %+v but is "+
 						"discovered in the JSON. Ignore the key.", soldComm)
 				}
 				soldComm.Key = nil


### PR DESCRIPTION
This PR updates go to 1.19.1 and fixes `make fmtcheck` and `make vet` error.