### PR TITLE
Display probe version on the target page of prometurbo

### DIFF
--- a/pkg/discovery/discovery_client.go
+++ b/pkg/discovery/discovery_client.go
@@ -2,14 +2,16 @@ package discovery
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/turbonomic/data-ingestion-framework/pkg/conf"
 	"github.com/turbonomic/data-ingestion-framework/pkg/data"
 	"github.com/turbonomic/data-ingestion-framework/pkg/dtofactory"
 	"github.com/turbonomic/data-ingestion-framework/pkg/registration"
+	prometurboversion "github.com/turbonomic/data-ingestion-framework/version"
 	"github.com/turbonomic/turbo-go-sdk/pkg/probe"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"strings"
 )
 
 // Implements the TurboDiscoveryClient interface
@@ -70,9 +72,16 @@ func (d *DIFDiscoveryClient) GetAccountValues() *probe.TurboTargetInfo {
 		StringValue: &targetName,
 	}
 
+	probeVersionField := registration.ProbeVersion
+	probeVersionVal := &proto.AccountValue{
+		Key:         &probeVersionField,
+		StringValue: &prometurboversion.Version,
+	}
+
 	accountValues := []*proto.AccountValue{
 		targetIdVal,
 		targetNameVal,
+		probeVersionVal,
 	}
 
 	targetInfo := probe.NewTurboTargetInfoBuilder(targetParams.ProbeCategory,

--- a/pkg/discovery/discovery_client.go
+++ b/pkg/discovery/discovery_client.go
@@ -72,6 +72,7 @@ func (d *DIFDiscoveryClient) GetAccountValues() *probe.TurboTargetInfo {
 		StringValue: &targetName,
 	}
 
+	//this field is used as probe version of the target for displaying in the UI
 	probeVersionField := registration.ProbeVersion
 	probeVersionVal := &proto.AccountValue{
 		Key:         &probeVersionField,

--- a/pkg/registration/registration_client.go
+++ b/pkg/registration/registration_client.go
@@ -11,6 +11,7 @@ import (
 const (
 	TargetIdField   string = "targetIdentifier" // this is used to reach the target
 	TargetNameField string = "Name"             // this is used to display the target in the UI
+	ProbeVersion    string = "probeVersion"     // this is used to display the probe version
 
 	propertyId string = "id"
 )
@@ -70,9 +71,19 @@ func (p *DIFRegistrationClient) GetAccountDefinition() []*proto.AccountDefEntry 
 		false).
 		Create()
 
+	// this field is used as probe version of the target for displaying in UI
+	probeVersion := builder.NewAccountDefEntryBuilder(ProbeVersion,
+		"Prometurbo Version",
+		"Release Version of Prometurbo Probe",
+		".*",
+		false,
+		false).
+		Create()
+
 	return []*proto.AccountDefEntry{
 		nameIDAcctDefEntry,
 		targetIDAcctDefEntry,
+		probeVersion,
 	}
 }
 


### PR DESCRIPTION
**Intent**

- Implement changes to display probe version on the target page for prometurbo

**Changes**
- Added a new field in Account Definition to display the probe version on the target page

**Testing**


![Screen Shot 2022-12-29 at 3 06 49 PM (2)](https://user-images.githubusercontent.com/112518353/210011249-fa1c72d5-9513-4038-a96b-289098f15d97.png)


![Screen Shot 2022-12-29 at 3 00 57 PM (2)](https://user-images.githubusercontent.com/112518353/210010740-21fb9774-f9d9-4e2e-94c2-d848dd6a206c.png)
