### PR TITLE
[OM-68744] Allow matching external application with multiple matching strings

### DIFF
--- a/configs/app-supply-chain-config.yaml
+++ b/configs/app-supply-chain-config.yaml
@@ -200,6 +200,7 @@ supplyChainNode:
         externalEntityMatchingProperty:
           - matchingProperty:
               propertyName: IP
+            delimiter: ","
       commoditiesSold:
         - RESPONSE_TIME
         - TRANSACTION


### PR DESCRIPTION
## Background
In 8.8.4, `kubeturbo` will create multiple matching strings for `ApplicationComponent`:
* `IP`: Support matching IP address from old `prometurbo`
* `IP-ClusterID`: Support matching IP plus unique clusterID from new `prometurbo`

As such, we need to modify the matching metadata of DIF to support this change.

## Implementation
* Add the `delimiter` field to the `externalEntityMatchingProperty` of `APPLICATION_COMPONENT `

## Test
* End-to-end test to make sure stitching works fine for both new and old `prometurbo`
  * From new `prometurbo` Service stitching
  ![image](https://user-images.githubusercontent.com/10012486/226045337-8a110037-c81e-43bf-8dc8-ea05c972f8d8.png)
  * From new `prometurbo` ApplicationComponent stitching
  ![image](https://user-images.githubusercontent.com/10012486/226045596-2bc81e13-9ab3-4f95-9bbb-412c8d39ddf6.png)

  * From old `prometurbo`
   ![image](https://user-images.githubusercontent.com/10012486/226046527-3350b21c-ea82-490f-ac5b-3f47cb5eb940.png)
