### PR TITLE
[OM-99777]:Support multi-stage build and update GO to 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,13 @@ vet:
 
 clean:
 	@rm -rf $(OUTPUT_DIR)/$(BINARY)* ${OUTPUT_DIR}/linux
+
+
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+REPO_NAME ?= icr.io/cpopen/turbonomic
+.PHONY: docker-buildx
+docker-buildx:
+	docker buildx create --name turbodif-builder
+	- docker buildx use turbodif-builder
+	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/turbodif:$(VERSION) -f build/Dockerfile.multi-archs --build-arg version=$(VERSION) .
+	docker buildx rm turbodif-builder

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,0 +1,48 @@
+# Building base image
+FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
+ARG version
+ENV TURBODIF_VERSION $version
+WORKDIR /workspace
+ADD . ./
+RUN make build
+
+FROM registry.access.redhat.com/ubi8-minimal
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
+ARG TARGETPLATFORM
+
+# Required OpenShift Labels
+LABEL name="Turbodif Container" \
+      vendor="Turbonomic" \
+      version="v8.0.0" \
+      release="1" \
+      summary="Performance assurance for the applications in Openshift" \
+      description="Hybrid Cloud Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." \
+### Required labels above - recommended below
+      url="https://www.turbonomic.com" \
+      io.k8s.description="Turbonomic Workload Automation Platform simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.  " \
+      io.k8s.display-name="Turbodif Operator" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="turbonomic, Multicloud Container"
+
+RUN microdnf update -y krb5-libs
+
+### add licenses to this directory
+COPY licenses /licenses
+
+COPY build/Dockerfile /Dockerfile
+
+### Setup user for build execution and application runtime
+ENV APP_ROOT=/opt/turbonomic
+ENV PATH=$PATH:${APP_ROOT}/bin
+
+RUN mkdir -p ${APP_ROOT}/bin
+RUN mkdir -p ${APP_ROOT}/conf
+COPY --from=builder /workspace/build/turbodif ${APP_ROOT}/bin/turbodif
+COPY configs/app-supply-chain-config.yaml ${APP_ROOT}/conf/app-supply-chain-config.yaml
+RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
+    chmod -R g=u ${APP_ROOT}
+
+####### Add app-specific needs below. #######
+USER 10001
+WORKDIR ${APP_ROOT}
+ENTRYPOINT ["/opt/turbonomic/bin/turbodif"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbonomic/data-ingestion-framework
 
-go 1.19
+go 1.20 //Make sure you sync the change to the file Dockerfile.multi-archs after you update the version here
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
# Intent
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Background
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Implementation
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Test

1. Run the command `make docker-buildx` to build multi-arch images and push it to docker(or icr)
Could see `turbodif` image is built and pushed to docker with multi-archs
![image](https://user-images.githubusercontent.com/61252360/230476325-f505037d-eb24-4036-a9d1-5af218c1d0ff.png)



3. Scan the image with `twistlock`
The report doesn't have any CVE issue on Go

[twistlock-scan-results-20230406-192924-N-UTC-9E39E055.results.csv](https://github.com/turbonomic/data-ingestion-framework/files/11173901/twistlock-scan-results-20230406-192924-N-UTC-9E39E055.results.csv)

5. Deploy the image in a K8s cluster and check if the pod can run 
The pod could run with the new image and there is  no outstanding error in the log