### PR TITLE
Fix the issue for supporting multi-platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ clean:
 
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 REPO_NAME ?= icr.io/cpopen/turbonomic
+multi-archs:
+	env GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY) ./cmd
 .PHONY: docker-buildx
 docker-buildx:
 	docker buildx create --name turbodif-builder
 	- docker buildx use turbodif-builder
-	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/turbodif:$(VERSION) -f build/Dockerfile.multi-archs --build-arg version=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --push --tag $(REPO_NAME)/turbodif:$(VERSION) -f build/Dockerfile.multi-archs --build-arg VERSION=$(VERSION) .
 	docker buildx rm turbodif-builder

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,10 +1,10 @@
 # Building base image
 FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
-ARG version
-ENV TURBODIF_VERSION $version
+ARG VERSION TARGETOS TARGETARCH
+ENV TURBODIF_VERSION $VERSION
 WORKDIR /workspace
 ADD . ./
-RUN make build
+RUN make multi-archs
 
 FROM registry.access.redhat.com/ubi8-minimal
 MAINTAINER Turbonomic <turbodeploy@turbonomic.com>


### PR DESCRIPTION
# Intent
To fix the problem that the `turbodif` binary in the ppc64le/arm64/s390x image is wrongly built

# Background
https://vmturbo.atlassian.net/browse/OM-100670

# Implementation
Pass the `GOOS` and `GOARCH` arguments to the build command


# Test
root@dawning1:~# docker run -it --entrypoint sh  kevin0204/turbodif:8.8.6-LAST
Unable to find image 'kevin0204/turbodif:8.8.6-LAST' locally
8.8.6-LAST: Pulling from kevin0204/turbodif
a3ece89037f7: Already exists 
d067a06c50dc: Pull complete 
9d926dc0fafe: Pull complete 
8d7e07db31ce: Pull complete 
716281b0b9dc: Pull complete 
7d43511192cd: Pull complete 
243b1d7a04b8: Pull complete 
5f16d3272d9b: Pull complete 
2eb639990689: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:031466b428b474bae1661eafb1cb2f688e362c228cb90e1e3f2a7383a820edc6
Status: Downloaded newer image for kevin0204/turbodif:8.8.6-LAST
sh-4.4$ uname -a
Linux 59acdd3d35cc 5.4.0-144-generic #161-Ubuntu SMP Fri Feb 3 14:49:07 UTC 2023 ppc64le ppc64le ppc64le GNU/Linux
sh-4.4$ exec /opt/turbonomic/bin/turbodif 
I0416 23:06:39.541156       1 main.go:37] Running turbodif VERSION: 8.8.6-LAST, GIT_COMMIT: 8cc44dbc5da5b72a669df17139796e42ddf1a94b, BUILD_TIME: Sun, 16 Apr 2023 11:54:20 +0000
```
