### PR TITLE
[TRB-40866]:Update Go version to 1.20.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 go:
-  - 1.19.4
+  - 1.20.4
 
 go_import_path: github.com/turbonomic/data-ingestion-framework
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,5 +1,5 @@
 # Building base image
-FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.4 AS builder
 ARG VERSION TARGETOS TARGETARCH
 ENV TURBODIF_VERSION $VERSION
 WORKDIR /workspace


### PR DESCRIPTION
# Intent
To solve the issue of  CVE-2023-24540
https://jsw.ibm.com/browse/TRB-40866

# Test
Please refer to the `twistlock` scan result

[twistlock-scan-results-20230602-154331-N-UTC-AB0F53A7.results.csv](https://github.com/turbonomic/data-ingestion-framework/files/11636864/twistlock-scan-results-20230602-154331-N-UTC-AB0F53A7.results.csv)
