### PR TITLE
[TRB-46405]: upgrade go version to 1.20.7 to fix CVE-2023-39533

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 go:
-  - 1.20.5
+  - 1.20.7
 
 go_import_path: github.com/turbonomic/data-ingestion-framework
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -7,7 +7,6 @@ ADD . ./
 RUN make multi-archs
 
 FROM registry.access.redhat.com/ubi8-minimal
-MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 ARG TARGETPLATFORM
 
 # Required OpenShift Labels


### PR DESCRIPTION
## Intent

Upgrade go version
to fix [CVE-2023-39533](https://cve.circl.lu/cve/CVE-2023-39533)

## Testing

Build dev image with the changes and scan it with twistlock, vulnerability issue resolved
[twistlock-scan-results-20230825-035925-069752000-UTC-3CFD8949.results.csv](https://github.com/turbonomic/data-ingestion-framework/files/12435412/twistlock-scan-results-20230825-035925-069752000-UTC-3CFD8949.results.csv)

